### PR TITLE
feat: Redesign /docs pages in Microsoft Windows 2000 style

### DIFF
--- a/app/docs/[id]/page.tsx
+++ b/app/docs/[id]/page.tsx
@@ -1,6 +1,5 @@
-import { Badge } from "@/registry/spell-ui/badge";
 import { allDocItems, getDoc, getDocSchema } from "@/lib/doc";
-import { ArrowLeft, ArrowRight, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { DocsTableOfContents } from "@/components/toc";
@@ -8,18 +7,9 @@ import { getTableOfContents } from "@/lib/toc";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { DocCopySection } from "@/components/doc-copy-section";
 import { siteConfig } from "@/lib/config";
 import { absoluteUrl, buildOgUrl, constructMetadata } from "@/lib/utils";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 
 export async function generateMetadata({
   params,
@@ -97,135 +87,173 @@ export default async function DocPage({
   }
 
   return (
-    <div className="container py-8 md:py-12">
-      <div className="xl:grid xl:grid-cols-[10px_1fr_200px] lg:grid-cols-[0px_1fr_200px] xl:gap-8 max-w-[1600px] mx-auto">
-        <div className="hidden xl:block" />
-        <article className="max-w-4xl prose dark:prose-invert w-full">
-          <header className="not-prose mb-8">
-            <Breadcrumb className="mb-2">
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink href="/docs/introduction">Docs</BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
+    <div
+      className="px-4 py-4"
+      style={{ fontFamily: "Tahoma, Verdana, Arial, sans-serif", backgroundColor: "#D4D0C8", minHeight: "100vh", paddingBottom: "32px" }}
+    >
+      <div className="xl:grid xl:grid-cols-[1fr_190px] xl:gap-4 max-w-[1400px] mx-auto">
+        {/* Main content panel — Win2k sunken panel */}
+        <div
+          className="win2k-panel"
+          style={{ backgroundColor: "#FFFFFF" }}
+        >
+          {/* Document title bar */}
+          <div
+            className="win2k-titlebar px-2 py-1"
+            style={{ fontSize: "11px" }}
+          >
+            <span>📄</span>
+            <span>{item.title} — Spell UI Docs</span>
+          </div>
+
+          <article
+            className="prose w-full p-4"
+            style={{ fontFamily: "Tahoma, Verdana, Arial, sans-serif", maxWidth: "none" }}
+          >
+            <header className="not-prose mb-4">
+              {/* Win2k breadcrumb toolbar */}
+              <div
+                className="flex items-center gap-1 mb-3 text-[11px] px-1 py-1 win2k-raised"
+                style={{ fontSize: "11px", backgroundColor: "#D4D0C8" }}
+              >
+                <span style={{ color: "#808080" }}>📁</span>
+                <Link href="/docs/introduction" style={{ color: "#0000FF", textDecoration: "none", fontSize: "11px" }}>Docs</Link>
+                <span style={{ color: "#808080" }}>›</span>
                 {isGettingStarted ? (
-                  <BreadcrumbItem>
-                    <BreadcrumbPage>{item.title}</BreadcrumbPage>
-                  </BreadcrumbItem>
+                  <span style={{ fontSize: "11px", fontWeight: "bold" }}>{item.title}</span>
                 ) : (
                   <>
-                    <BreadcrumbItem>
-                      <BreadcrumbLink href="/docs/components">Components</BreadcrumbLink>
-                    </BreadcrumbItem>
-                    <BreadcrumbSeparator />
-                    <BreadcrumbItem>
-                      <BreadcrumbPage>{item.title}</BreadcrumbPage>
-                    </BreadcrumbItem>
+                    <Link href="/docs/components" style={{ color: "#0000FF", textDecoration: "none", fontSize: "11px" }}>Components</Link>
+                    <span style={{ color: "#808080" }}>›</span>
+                    <span style={{ fontSize: "11px", fontWeight: "bold" }}>{item.title}</span>
                   </>
                 )}
-              </BreadcrumbList>
-            </Breadcrumb>
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
-                <h1 className="scroll-m-20 text-3xl font-semibold tracking-tighter">
-                  {item.title}
-                </h1>
-                <p className="text-base text-muted-foreground">
-                  {item.description}
-                </p>
               </div>
-              <div className="flex items-center gap-2">
-                <DocCopySection content={rawContent} url={`/docs/${id}`} />
-                <Button
-                  variant="secondary"
-                  className="rounded-full size-8 shadow-none active:scale-[0.97] will-change-transform ease-out duration-150 transition-transform"
-                  size="icon"
-                  disabled={!prevDoc}
-                  asChild={!!prevDoc}
-                >
-                  {prevDoc
-                    ? (
-                      <Link
-                        href={`/docs/${prevDoc.id}`}
-                        title={prevDoc.title}
-                      >
-                        <ArrowLeft className="text-muted-foreground" />
-                      </Link>
-                    )
-                    : (
-                      <span>
-                        <ArrowLeft className="text-muted-foreground" />
-                      </span>
-                    )}
-                </Button>
-                <Button
-                  variant="secondary"
-                  className="rounded-full size-8 shadow-none active:scale-[0.97] will-change-transform ease-out duration-300 transition-colors"
-                  size="icon"
-                  disabled={!nextDoc}
-                  asChild={!!nextDoc}
-                >
-                  {nextDoc
-                    ? (
-                      <Link
-                        href={`/docs/${nextDoc.id}`}
-                        title={nextDoc.title}
-                      >
-                        <ArrowRight className="text-muted-foreground" />
-                      </Link>
-                    )
-                    : (
-                      <span>
-                        <ArrowRight className="text-muted-foreground" />
-                      </span>
-                    )}
-                </Button>
-              </div>
-            </div>
 
-            {item.meta?.docs && item.meta?.docs.length > 0 && (
-              <div className="flex items-center space-x-2 pt-4">
-                {item.meta?.docs?.map((doc) => (
-                  <Badge key={doc.title} variant="secondary" asChild>
-                    <a href={doc.url} target="_blank" rel="noopener noreferrer">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <h1
+                    style={{
+                      fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+                      fontSize: "18px",
+                      fontWeight: "bold",
+                      color: "#000000",
+                      margin: "0 0 4px 0",
+                      lineHeight: "1.3",
+                    }}
+                  >
+                    {item.title}
+                  </h1>
+                  <p
+                    style={{
+                      fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+                      fontSize: "12px",
+                      color: "#444444",
+                      margin: "0",
+                    }}
+                  >
+                    {item.description}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <DocCopySection content={rawContent} url={`/docs/${id}`} />
+                  <button
+                    className="win2k-button text-[11px] flex items-center gap-1"
+                    style={{ opacity: prevDoc ? 1 : 0.4, cursor: prevDoc ? "pointer" : "default" }}
+                  >
+                    {prevDoc ? (
+                      <Link href={`/docs/${prevDoc.id}`} title={prevDoc.title} style={{ textDecoration: "none", color: "#000000" }}>
+                        ◀ Back
+                      </Link>
+                    ) : (
+                      <span>◀ Back</span>
+                    )}
+                  </button>
+                  <button
+                    className="win2k-button text-[11px] flex items-center gap-1"
+                    style={{ opacity: nextDoc ? 1 : 0.4, cursor: nextDoc ? "pointer" : "default" }}
+                  >
+                    {nextDoc ? (
+                      <Link href={`/docs/${nextDoc.id}`} title={nextDoc.title} style={{ textDecoration: "none", color: "#000000" }}>
+                        Next ▶
+                      </Link>
+                    ) : (
+                      <span>Next ▶</span>
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {item.meta?.docs && item.meta?.docs.length > 0 && (
+                <div className="flex items-center gap-2 mt-3 flex-wrap">
+                  {item.meta?.docs?.map((doc) => (
+                    <a
+                      key={doc.title}
+                      href={doc.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="win2k-button text-[11px] flex items-center gap-1"
+                      style={{ textDecoration: "none", color: "#000000" }}
+                    >
                       {doc.title}
-                      <ExternalLink className="w-4 h-4" />
+                      <ExternalLink style={{ width: "12px", height: "12px" }} />
                     </a>
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </header>
-          <Doc />
+                  ))}
+                </div>
+              )}
 
-          <nav className="not-prose flex items-center justify-between mt-12 pt-12 border-t">
-            {prevDoc ? (
-              <Link
-                href={`/docs/${prevDoc.id}`}
-                className="max-w-40 flex group flex-col font-medium items-start gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors ease-out duration-200"
-              >
-                <span className="transition-colors text-muted-foreground/75 group-hover:text-muted-foreground ease-out duration-200">Previous</span>
-                <span className="truncate">{prevDoc.title}</span>
-              </Link>
-            ) : (
-              <div />
-            )}
-            {nextDoc ? (
-              <Link
-                href={`/docs/${nextDoc.id}`}
-                className="max-w-40 flex group flex-col font-medium items-end gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors ease-out duration-200"
-              >
-                <span className="transition-colors text-muted-foreground/75 group-hover:text-muted-foreground ease-out duration-200">Next</span>
-                <span className="truncate">{nextDoc.title}</span>
-              </Link>
-            ) : (
-              <div />
-            )}
-          </nav>
-        </article>
+              {/* Separator rule */}
+              <div
+                className="mt-3"
+                style={{ borderTop: "1px solid #808080", borderBottom: "1px solid #FFFFFF" }}
+              />
+            </header>
 
-        <aside className="hidden xl:block sticky top-[90px] h-fit">
-          <DocsTableOfContents toc={toc} docId={id} />
+            <Doc />
+
+            {/* Bottom navigation */}
+            <nav
+              className="not-prose flex items-center justify-between mt-6 pt-3"
+              style={{ borderTop: "1px solid #808080", borderBottom: "none" }}
+            >
+              {prevDoc ? (
+                <Link
+                  href={`/docs/${prevDoc.id}`}
+                  className="win2k-button text-[11px]"
+                  style={{ textDecoration: "none", color: "#000000" }}
+                >
+                  ◀ {prevDoc.title}
+                </Link>
+              ) : (
+                <div />
+              )}
+              {nextDoc ? (
+                <Link
+                  href={`/docs/${nextDoc.id}`}
+                  className="win2k-button text-[11px]"
+                  style={{ textDecoration: "none", color: "#000000" }}
+                >
+                  {nextDoc.title} ▶
+                </Link>
+              ) : (
+                <div />
+              )}
+            </nav>
+          </article>
+        </div>
+
+        {/* TOC — Win2k panel */}
+        <aside className="hidden xl:block">
+          <div className="win2k-panel sticky top-[90px] h-fit">
+            <div
+              className="win2k-titlebar px-2 py-1 text-[11px]"
+            >
+              📋 On This Page
+            </div>
+            <div style={{ backgroundColor: "#D4D0C8" }}>
+              <DocsTableOfContents toc={toc} docId={id} />
+            </div>
+          </div>
         </aside>
       </div>
     </div>

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -8,16 +8,50 @@ const docSchema = await getDocSchema();
 
 export default function DocLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex">
+    <div className="flex flex-col" style={{ fontFamily: "Tahoma, Verdana, Arial, sans-serif" }}>
       <SidebarProvider className="flex flex-col">
         <SiteHeader docSchema={docSchema} />
-        <div className="3xl:max-w-screen-2xl mx-auto flex w-full pt-14">
+        {/* Offset for the 3-row Win2k header: titlebar(28px) + menubar(28px) + toolbar(30px) = ~86px */}
+        <div
+          className="3xl:max-w-screen-2xl mx-auto flex w-full"
+          style={{ paddingTop: "86px" }}
+        >
           <AppSidebar docSchema={docSchema} />
-          <SidebarInset>
+          <SidebarInset style={{ backgroundColor: "#D4D0C8" }}>
             {children}
           </SidebarInset>
         </div>
       </SidebarProvider>
+
+      {/* Win2k Status Bar */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-40 flex items-center justify-between px-2 py-0.5 text-[11px]"
+        style={{
+          backgroundColor: "#D4D0C8",
+          borderTop: "2px solid",
+          borderColor: "#FFFFFF #808080 #808080 #FFFFFF",
+          fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className="px-4 py-0.5 text-[11px]"
+            style={{
+              borderRight: "1px solid #808080",
+              borderBottom: "1px solid #FFFFFF",
+            }}
+          >
+            ✓ Done
+          </span>
+          <span className="text-[11px] text-[#444444]">Spell UI Documentation</span>
+        </div>
+        <div
+          className="flex items-center gap-1 text-[11px] px-2"
+          style={{ borderLeft: "1px solid #808080" }}
+        >
+          <span>🌐 Internet</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,74 +56,89 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(1 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-  --rotating-border-color: var(--color-neutral-200);
+  /* Windows 2000 color palette */
+  --win2k-silver: #D4D0C8;
+  --win2k-white: #FFFFFF;
+  --win2k-dark: #404040;
+  --win2k-black: #000000;
+  --win2k-teal: #008080;
+  --win2k-blue-link: #0000FF;
+  --win2k-highlight: #0A246A;
+  --win2k-highlight-text: #FFFFFF;
+  --win2k-shadow: #808080;
+  --win2k-dark-shadow: #404040;
+  --win2k-light: #FFFFFF;
+  --win2k-button-face: #D4D0C8;
+
+  --radius: 0rem;
+  --background: #D4D0C8;
+  --foreground: #000000;
+  --card: #D4D0C8;
+  --card-foreground: #000000;
+  --popover: #D4D0C8;
+  --popover-foreground: #000000;
+  --primary: #000080;
+  --primary-foreground: #FFFFFF;
+  --secondary: #C0C0C0;
+  --secondary-foreground: #000000;
+  --muted: #C8C4BC;
+  --muted-foreground: #444444;
+  --accent: #0A246A;
+  --accent-foreground: #FFFFFF;
+  --destructive: #FF0000;
+  --border: #808080;
+  --input: #FFFFFF;
+  --ring: #0000FF;
+  --chart-1: #008080;
+  --chart-2: #000080;
+  --chart-3: #800000;
+  --chart-4: #008000;
+  --chart-5: #800080;
+  --sidebar: #D4D0C8;
+  --sidebar-foreground: #000000;
+  --sidebar-primary: #000080;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #0A246A;
+  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-border: #808080;
+  --sidebar-ring: #0000FF;
+  --rotating-border-color: #808080;
 }
 
+/* Win2000 forces light mode always — no dark variant needed */
 .dark {
-  --background: oklch(0.1149 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(22.213% 0.00003 271.152);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.1149 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
-  --rotating-border-color: var(--muted);
+  --background: #D4D0C8;
+  --foreground: #000000;
+  --card: #D4D0C8;
+  --card-foreground: #000000;
+  --popover: #D4D0C8;
+  --popover-foreground: #000000;
+  --primary: #000080;
+  --primary-foreground: #FFFFFF;
+  --secondary: #C0C0C0;
+  --secondary-foreground: #000000;
+  --muted: #C8C4BC;
+  --muted-foreground: #444444;
+  --accent: #0A246A;
+  --accent-foreground: #FFFFFF;
+  --destructive: #FF0000;
+  --border: #808080;
+  --input: #FFFFFF;
+  --ring: #0000FF;
+  --chart-1: #008080;
+  --chart-2: #000080;
+  --chart-3: #800000;
+  --chart-4: #008000;
+  --chart-5: #800080;
+  --sidebar: #D4D0C8;
+  --sidebar-foreground: #000000;
+  --sidebar-primary: #000080;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #0A246A;
+  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-border: #808080;
+  --sidebar-ring: #0000FF;
+  --rotating-border-color: #808080;
 }
 
 @layer base {
@@ -132,7 +147,180 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: Tahoma, Verdana, Arial, sans-serif !important;
+    font-size: 11px;
   }
+  a {
+    color: #0000FF;
+    text-decoration: underline;
+  }
+  a:visited {
+    color: #800080;
+  }
+  a:hover {
+    color: #0000CC;
+  }
+}
+
+/* Windows 2000 raised/sunken border utilities */
+.win2k-raised {
+  border-style: solid;
+  border-width: 2px;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  box-shadow: inset 1px 1px 0 #DFDFDF, inset -1px -1px 0 #404040;
+}
+
+.win2k-sunken {
+  border-style: solid;
+  border-width: 2px;
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  box-shadow: inset 1px 1px 0 #404040, inset -1px -1px 0 #DFDFDF;
+}
+
+.win2k-button {
+  background-color: #D4D0C8;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  box-shadow: inset 1px 1px 0 #DFDFDF, inset -1px -1px 0 #404040;
+  padding: 3px 8px;
+  font-family: Tahoma, Verdana, Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: pointer;
+}
+
+.win2k-button:active {
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  box-shadow: inset 1px 1px 0 #404040, inset -1px -1px 0 #DFDFDF;
+}
+
+.win2k-titlebar {
+  background: linear-gradient(to right, #000080, #1084d0);
+  color: #FFFFFF;
+  font-family: Tahoma, Verdana, Arial, sans-serif;
+  font-size: 11px;
+  font-weight: bold;
+  padding: 3px 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.win2k-menubar {
+  background-color: #D4D0C8;
+  border-bottom: 1px solid #808080;
+  padding: 2px 4px;
+  display: flex;
+  gap: 0;
+}
+
+.win2k-menubar-item {
+  padding: 3px 8px;
+  font-family: Tahoma, Verdana, Arial, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.win2k-menubar-item:hover {
+  background-color: #0A246A;
+  color: #FFFFFF;
+  text-decoration: none;
+}
+
+.win2k-panel {
+  background-color: #D4D0C8;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  box-shadow: inset 1px 1px 0 #DFDFDF, inset -1px -1px 0 #404040;
+}
+
+.win2k-inset {
+  background-color: #FFFFFF;
+  border-style: solid;
+  border-width: 2px;
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  box-shadow: inset 1px 1px 0 #404040, inset -1px -1px 0 #DFDFDF;
+}
+
+.win2k-selected {
+  background-color: #0A246A !important;
+  color: #FFFFFF !important;
+}
+
+/* Override shiki code blocks for Win2k feel */
+.shiki,
+.shiki span {
+  color: var(--shiki-light) !important;
+  background-color: var(--shiki-light-bg) !important;
+  font-family: "Courier New", Courier, monospace !important;
+  font-size: 11px !important;
+}
+
+/* Win2k prose overrides */
+.prose {
+  font-family: Tahoma, Verdana, Arial, sans-serif;
+  font-size: 12px;
+  color: #000000;
+}
+.prose h1, .prose h2, .prose h3, .prose h4 {
+  font-family: Tahoma, Verdana, Arial, sans-serif;
+  color: #000000;
+}
+.prose a {
+  color: #0000FF;
+}
+.prose code {
+  font-family: "Courier New", Courier, monospace !important;
+  font-size: 11px !important;
+  background-color: #FFFFFF;
+  border: 1px solid #808080;
+  padding: 0 3px;
+  color: #000000;
+}
+.prose pre {
+  background-color: #FFFFFF !important;
+  border: 2px solid;
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  box-shadow: inset 1px 1px 0 #404040, inset -1px -1px 0 #DFDFDF;
+  border-radius: 0 !important;
+  font-family: "Courier New", Courier, monospace !important;
+  font-size: 11px !important;
+}
+.prose pre code {
+  border: none;
+  background: none;
+  padding: 0;
+}
+.prose blockquote {
+  border-left: 3px solid #808080;
+  background-color: #E8E4DC;
+  padding: 4px 8px;
+  font-style: normal;
+  color: #000000;
+}
+.prose table {
+  border-collapse: collapse;
+  font-size: 11px;
+}
+.prose th {
+  background-color: #D4D0C8;
+  border: 1px solid #808080;
+  padding: 3px 6px;
+  font-weight: bold;
+}
+.prose td {
+  border: 1px solid #808080;
+  padding: 3px 6px;
+}
+.prose hr {
+  border: none;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #FFFFFF;
 }
 
 @utility container {
@@ -172,8 +360,8 @@ summary {
 
 .dark .shiki,
 .dark .shiki span {
-  color: var(--shiki-dark) !important;
-  background-color: #0f0f0f !important;
+  color: var(--shiki-light) !important;
+  background-color: var(--shiki-light-bg) !important;
 }
 
 .subheading-anchor {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,8 +52,8 @@ export default async function RootLayout({
         <JotaiProvider>
           <ThemeProvider
             attribute="class"
-            defaultTheme="dark"
-            enableSystem
+            defaultTheme="light"
+            enableSystem={false}
             disableTransitionOnChange
           >
             {children}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -30,37 +30,83 @@ export function AppSidebar({
   };
 
   return (
-    <Sidebar className="mt-14" {...props}>
-      {/* mt-14 > for header height */}
-      <SidebarContent
-        className="max-h-[calc(100vh-100px)] overflow-y-auto"
+    <Sidebar
+      className="mt-0"
+      style={{
+        backgroundColor: "#D4D0C8",
+        borderRight: "2px solid",
+        borderRightColor: "#808080",
+        fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+      }}
+      {...props}
+    >
+      {/* Explorer-style sidebar header */}
+      <div
+        className="px-2 py-1.5 text-[11px] font-bold"
         style={{
-          maskImage:
-            "linear-gradient(to bottom, transparent 0, rgba(0,0,0,0.2) 1rem, black 2rem, black calc(100% - 2rem), rgba(0,0,0,0.2) calc(100% - 1rem), transparent 100%)",
+          backgroundColor: "#D4D0C8",
+          borderBottom: "1px solid #808080",
+          color: "#000080",
         }}
       >
-        <div className="h-4 shrink-0" />
+        📁 Explorer
+      </div>
+
+      <SidebarContent
+        className="max-h-[calc(100vh-140px)] overflow-y-auto"
+        style={{ backgroundColor: "#D4D0C8", maskImage: "none" }}
+      >
+        <div className="h-1 shrink-0" />
         {data.navMain.map((group) => (
-          <SidebarGroup key={group.title}>
-            <SidebarGroupLabel>{group.title}</SidebarGroupLabel>
+          <SidebarGroup key={group.title} style={{ padding: "0" }}>
+            <SidebarGroupLabel
+              style={{
+                fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+                fontSize: "11px",
+                fontWeight: "bold",
+                color: "#000000",
+                padding: "4px 8px 2px 8px",
+                textTransform: "none",
+                letterSpacing: "0",
+              }}
+            >
+              📂 {group.title}
+            </SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu>
-                {group.items.map((navItem) => (
-                  <SidebarMenuItem key={navItem.id}>
-                    <SidebarMenuButton
-                      className="data-[active=true]:shadow-[0_0_0_1px_rgba(0,0,0,.08),_0px_2px_2px_rgba(0,0,0,.04)] data-[active=true]:not-dark:bg-white transition-all"
-                      asChild
-                      isActive={pathname === `/docs/${navItem.id}`}
-                      onClick={() => {
-                        if (isMobile) {
-                          toggleSidebar();
-                        }
-                      }}
-                    >
-                      <Link href={`/docs/${navItem.id}`}>{navItem.title}</Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
+              <SidebarMenu style={{ gap: "0" }}>
+                {group.items.map((navItem) => {
+                  const isActive = pathname === `/docs/${navItem.id}`;
+                  return (
+                    <SidebarMenuItem key={navItem.id} style={{ margin: "0" }}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive}
+                        onClick={() => {
+                          if (isMobile) {
+                            toggleSidebar();
+                          }
+                        }}
+                        style={{
+                          borderRadius: "0",
+                          padding: "2px 8px 2px 20px",
+                          fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+                          fontSize: "11px",
+                          color: isActive ? "#FFFFFF" : "#000000",
+                          backgroundColor: isActive ? "#0A246A" : "transparent",
+                          margin: "0",
+                          height: "auto",
+                          minHeight: "20px",
+                        }}
+                      >
+                        <Link href={`/docs/${navItem.id}`}>
+                          <span style={{ userSelect: "none" }}>
+                            📄 {navItem.title}
+                          </span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -2,57 +2,73 @@ import { DocSchema } from "@/lib/types";
 import { SearchForm } from "./command-menu";
 import { MobileNav } from "./mobile-nav";
 import { SpellLogo } from "./spell-logo";
-import { ConditionalThemeToggle } from "./conditional-theme-toggle";
 import { GithubStars } from "./github-stars";
 import { AuthButton } from "./auth-button";
 import Link from "next/link";
 
 export default function SiteHeader({ docSchema }: { docSchema?: DocSchema }) {
   return (
-    <header className="fixed bg-background top-0 left-0 right-0 z-50 w-full border-b border-border">
-      <div className="flex justify-between w-full h-14 items-center gap-4 3xl:max-w-screen-2xl px-4 mx-auto">
-        <div className="flex items-center gap-6">
-          <div className="flex items-center gap-3">
-            {docSchema && <MobileNav docSchema={docSchema} className="md:hidden" />}
-            <Link href="/" className="flex items-center gap-1.5">
-              <SpellLogo size={24} />
-              <h1 className="hidden md:inline font-medium text-nowrap" translate="no">
-                Spell UI
-              </h1>
-            </Link>
-          </div>
-          <nav className="hidden md:flex items-center gap-4 md:gap-6 text-sm">
-            <Link
-              href="/docs/introduction"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Docs
-            </Link>
-            <Link
-              href="/docs/components"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Components
-            </Link>
-            <Link
-              href="/docs/mcp"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              MCP
-            </Link>
-            <Link
-              href="/sponsor"
-              className="text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Sponsor
-            </Link>
-          </nav>
+    <header className="fixed top-0 left-0 right-0 z-50 w-full" style={{ fontFamily: "Tahoma, Verdana, Arial, sans-serif" }}>
+      {/* Title bar — Win2000 gradient bar */}
+      <div className="win2k-titlebar h-7 flex items-center justify-between px-2 select-none">
+        <div className="flex items-center gap-1.5">
+          <SpellLogo size={14} className="[&_path]:fill-white" />
+          <span className="text-xs font-bold text-white tracking-tight">Spell UI — Documentation</span>
         </div>
-        <div className="flex gap-2 lg:gap-3 items-center">
+        {/* Window control buttons */}
+        <div className="flex items-center gap-0.5">
+          <button className="win2k-button !px-1.5 !py-0 text-[10px] min-w-[16px] h-[14px] leading-none font-bold">_</button>
+          <button className="win2k-button !px-1.5 !py-0 text-[10px] min-w-[16px] h-[14px] leading-none font-bold">□</button>
+          <button className="win2k-button !px-1.5 !py-0 text-[10px] min-w-[16px] h-[14px] leading-none font-bold text-[#cc0000]">✕</button>
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div className="win2k-menubar flex items-center justify-between">
+        <div className="flex items-center gap-0">
+          {docSchema && <MobileNav docSchema={docSchema} className="md:hidden mr-2" />}
+          <Link href="/" className="win2k-menubar-item font-bold flex items-center gap-1">
+            <SpellLogo size={14} />
+            <span className="hidden md:inline">File</span>
+          </Link>
+          <Link href="/docs/introduction" className="win2k-menubar-item">
+            <span className="underline">D</span>ocs
+          </Link>
+          <Link href="/docs/components" className="win2k-menubar-item">
+            <span className="underline">C</span>omponents
+          </Link>
+          <Link href="/docs/mcp" className="win2k-menubar-item">
+            <span className="underline">M</span>CP
+          </Link>
+          <Link href="/sponsor" className="win2k-menubar-item">
+            <span className="underline">S</span>ponsor
+          </Link>
+          <span className="win2k-menubar-item text-[#808080] cursor-default">Help</span>
+        </div>
+        <div className="flex items-center gap-1 pr-1">
           {docSchema && <SearchForm docSchema={docSchema} />}
           <GithubStars />
           <AuthButton />
-          <ConditionalThemeToggle />
+        </div>
+      </div>
+
+      {/* Toolbar / Address bar */}
+      <div
+        className="flex items-center gap-2 px-2 py-1 text-[11px]"
+        style={{ backgroundColor: "#D4D0C8", borderBottom: "1px solid #808080" }}
+      >
+        <button className="win2k-button text-[10px]">◀ Back</button>
+        <button className="win2k-button text-[10px]">▶ Forward</button>
+        <button className="win2k-button text-[10px]">⟳ Refresh</button>
+        <div className="flex items-center gap-1 flex-1">
+          <span className="text-[11px] shrink-0">Address:</span>
+          <div
+            className="win2k-inset flex-1 px-1 py-0.5 text-[11px] truncate"
+            style={{ backgroundColor: "#FFFFFF", minWidth: 0 }}
+          >
+            spell-ui.com/docs/introduction
+          </div>
+          <button className="win2k-button text-[10px]">Go</button>
         </div>
       </div>
     </header>

--- a/components/toc.tsx
+++ b/components/toc.tsx
@@ -71,45 +71,52 @@ export function DocsTableOfContents({
 
   return (
     <div
-      className={cn(
-        "flex flex-col gap-2 p-4 pt-0 text-sm",
-        className,
-      )}
+      className={cn("flex flex-col p-2 text-[11px]", className)}
+      style={{ fontFamily: "Tahoma, Verdana, Arial, sans-serif", backgroundColor: "#D4D0C8" }}
     >
-      <p className="text-primary bg-background sticky top-0 h-6 mb-2 text-[0.85rem] flex gap-1.5 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 items-center">
-        <MenuLeft />
-        On This Page
-      </p>
       {toc.map((item) => (
         <a
           key={item.url}
           href={item.url}
-          className="text-muted-foreground hover:text-foreground data-[active=true]:text-foreground data-[active=true]:font-medium text-[0.9rem] no-underline transition-colors data-[depth=3]:pl-4 data-[depth=4]:pl-6"
+          style={{
+            display: "block",
+            padding: "2px 4px",
+            fontSize: "11px",
+            textDecoration: "none",
+            fontFamily: "Tahoma, Verdana, Arial, sans-serif",
+            paddingLeft: item.depth >= 3 ? (item.depth >= 4 ? "20px" : "12px") : "4px",
+            backgroundColor: item.url === `#${activeHeading}` ? "#0A246A" : "transparent",
+            color: item.url === `#${activeHeading}` ? "#FFFFFF" : "#0000FF",
+            fontWeight: item.url === `#${activeHeading}` ? "bold" : "normal",
+          }}
           data-active={item.url === `#${activeHeading}`}
           data-depth={item.depth}
         >
           {item.title}
         </a>
       ))}
-      <Separator orientation="horizontal" className="my-2" />
-      <div className="flex flex-col gap-2">
+      <div
+        className="my-2"
+        style={{ borderTop: "1px solid #808080", borderBottom: "1px solid #FFFFFF" }}
+      />
+      <div className="flex flex-col gap-1">
         {docId && (
           <Link
             href={`${siteConfig.links.github}/edit/main/docs/${docId}/doc.mdx`}
             target="_blank"
             rel="noopener noreferrer"
-            className="transition-colors hover:text-foreground text-muted-foreground [&_svg]:size-3 flex gap-1.5 items-center"
+            style={{ color: "#0000FF", fontSize: "11px", display: "flex", alignItems: "center", gap: "4px" }}
             onClick={() => trackEvent("click_edit_page", { doc: docId })}
           >
-            <SquarePen />
+            <SquarePen style={{ width: "11px", height: "11px" }} />
             Edit this page
           </Link>
         )}
         <Link
           href={siteConfig.links.tom}
-          className="transition-colors hover:text-foreground text-muted-foreground [&_svg]:size-3 flex gap-1.5 items-center"
+          style={{ color: "#0000FF", fontSize: "11px", display: "flex", alignItems: "center", gap: "4px" }}
         >
-          <SiX className="pl-[1px]" />
+          <SiX style={{ width: "11px", height: "11px" }} />
           <span>Follow @tomm_ui</span>
         </Link>
       </div>


### PR DESCRIPTION
## Windows 2000 Docs Redesign

Redesigns the entire `/docs` section to match the authentic Microsoft Windows 2000 aesthetic:

### Changes
- **`app/globals.css`** — New Win2k color system: silver `#D4D0C8` background, `#000080` navy primary, `#008080` teal accents, black text on white. Added `.win2k-raised`, `.win2k-sunken`, `.win2k-button`, `.win2k-titlebar`, `.win2k-menubar`, `.win2k-panel`, `.win2k-inset` utility classes with authentic 3D beveled borders. Prose overrides for tables, code blocks, blockquotes, and HR. Forces light mode in `.dark` too.
- **`components/site-header.tsx`** — Three-row Win2k chrome: gradient navy title bar with window control buttons (_, □, ✕), a classic menu bar with underlined keyboard shortcuts, and an address bar with Back/Forward/Refresh/Go buttons.
- **`app/docs/layout.tsx`** — Adjusted padding-top for taller 3-row header (~86px). Win2k status bar pinned to the bottom ("✓ Done | 🌐 Internet").
- **`components/app-sidebar.tsx`** — Explorer-style sidebar with 📁/📄 icons, navy blue selected state, no rounded corners, Win2k-style group labels.
- **`app/docs/[id]/page.tsx`** — Content wrapped in a Win2k panel with title bar, raised breadcrumb toolbar, Win2k navigation buttons (◀ Back / Next ▶), and sunken inset code/content area.
- **`components/toc.tsx`** — TOC styled with Win2k active highlight (navy on selected item), Tahoma font, classic hyperlink blue links.
- **`app/layout.tsx`** — Forces `defaultTheme="light"` and disables system theme to prevent dark mode overriding Win2k palette.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Windows 2000-inspired UI aesthetic throughout the application.
  * Added a status bar at the bottom of the viewport.
  * Added toolbar navigation with back/forward/refresh controls and address display.

* **Style**
  * Changed default theme from dark to light.
  * Redesigned navigation, sidebar, header, and documentation panels with retro-inspired styling.
  * Updated button styling and visual indicators across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->